### PR TITLE
correct a typo in the rartifactory_search method

### DIFF
--- a/resources/artifact.rb
+++ b/resources/artifact.rb
@@ -30,7 +30,7 @@ def artifactory_checksum_search
 end
 
 def artifactory_search
-  artifact = Resource::Artifact.seach(name: search).first
+  artifact = Resource::Artifact.search(name: search).first
   artifact
 end
 


### PR DESCRIPTION
There was a typo in the artifactory_search function (seach instead of search)